### PR TITLE
fix: more precise import path for @mui/material

### DIFF
--- a/packages/100/src/utils/createSvgIcon.tsx
+++ b/packages/100/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js

--- a/packages/200/src/utils/createSvgIcon.tsx
+++ b/packages/200/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js

--- a/packages/300/src/utils/createSvgIcon.tsx
+++ b/packages/300/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js

--- a/packages/400/src/utils/createSvgIcon.tsx
+++ b/packages/400/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js

--- a/packages/500/src/utils/createSvgIcon.tsx
+++ b/packages/500/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js

--- a/packages/600/src/utils/createSvgIcon.tsx
+++ b/packages/600/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js

--- a/packages/700/src/utils/createSvgIcon.tsx
+++ b/packages/700/src/utils/createSvgIcon.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 /**
  * @source https://github.com/mui/material-ui/packages/mui-material/src/utils/createSvgIcon.js


### PR DESCRIPTION
When using the cjs build the `@mui/material` import path, converted to a require will import the whole material lib.

Even if most modern bundlers will use the esm build, Jest does not which means much slower test execution.

The suggested fix includes only a more specific import of `SvgIcon`. We can only import the second level as described here https://mui.com/material-ui/guides/minimizing-bundle-size/#option-one-use-path-imports

